### PR TITLE
[macos] Allow compatibility libraries in signed guest agents

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,7 +42,7 @@ universal_binaries:
     # GoReleaser's macOS signer uses the executable name as its identifier.
     name_template: tart-guest-agent
     hooks:
-      post: '{{ if .IsSnapshot }}codesign --force --sign - --identifier tart-guest-agent --timestamp=none "{{ .Path }}"{{ else }}true{{ end }}'
+      post: '{{ if .IsSnapshot }}codesign --force --sign - --identifier tart-guest-agent --options runtime --entitlements packaging/macos-entitlements.plist --timestamp=none "{{ .Path }}"{{ else }}true{{ end }}'
 
 notarize:
   macos:
@@ -50,6 +50,7 @@ notarize:
       sign:
         certificate: "{{ .Env.MACOS_SIGN_P12 }}"
         password: "{{ .Env.MACOS_SIGN_PASSWORD }}"
+        entitlements: packaging/macos-entitlements.plist
 
 archives:
   - name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
@@ -62,7 +63,8 @@ archives:
             {{ if eq .Os "darwin" }}
             sh -ec 'lipo "$1" -verify_arch arm64 x86_64;
             codesign --verify --all-architectures --strict "$1";
-            for arch in arm64 x86_64; do codesign --verify --strict --arch "$arch" "$1"; done'
+            for arch in arm64 x86_64; do codesign --verify --strict --arch "$arch" "$1"; done;
+            sh packaging/verify-macos-signing.sh "$1"'
             _ "{{ .Dist }}/tart-guest-agent_darwin_all/tart-guest-agent"
             {{ else }}true{{ end }}
 

--- a/README.md
+++ b/README.md
@@ -22,3 +22,24 @@ To run all features appropriate for a given context, use component groups:
 * `--run-agent`
     * implies `--run-vdagent --run-rpc` 
     * example usage: [`tart-guest-agent.plist`](https://github.com/cirruslabs/macos-image-templates/blob/main/data/tart-guest-agent.plist)
+
+## macOS signing and guest compatibility libraries
+
+Darwin releases retain Hardened Runtime and the `tart-guest-agent` signing
+identifier. They allow DYLD environment variables and disable library validation
+so image builders can opt the agent into a guest-installed compatibility library,
+such as the Tart Metal shim, without re-signing it and changing its TCC identity.
+These exceptions permit loading libraries not signed by the agent's developer;
+they do not install a library or enable injection by default. Keep any configured
+library and launchd plist root-owned and non-writable by untrusted users. The same
+binary implements agent and daemon modes, so both carry these entitlements.
+
+Snapshots use the same runtime options and entitlements with an ad-hoc signature.
+The existing macOS PR tests build the real agent and check that a hardened binary
+rejects injection without the entitlements and accepts it with them. The archive
+hook repeats the check against the final signed release executable and checks
+entitlements for every architecture. Run it manually with:
+
+```sh
+sh packaging/verify-macos-signing.sh /path/to/tart-guest-agent
+```

--- a/packaging/macos-entitlements.plist
+++ b/packaging/macos-entitlements.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/packaging/macos_signing_test.go
+++ b/packaging/macos_signing_test.go
@@ -1,0 +1,56 @@
+//go:build darwin
+
+package packaging_test
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Exercise the real agent, not a stand-in executable. This runs in the existing
+// macOS PR test job without accessing release signing credentials.
+func TestMacOSSigning(t *testing.T) {
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	binary := filepath.Join(t.TempDir(), "tart-guest-agent")
+	//nolint:gosec // The output path is owned by this test.
+	build := exec.CommandContext(t.Context(), "go", "build", "-o", binary, "./cmd")
+	build.Dir = root
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build agent: %v\n%s", err, output)
+	}
+
+	sign := func(entitlements bool) {
+		t.Helper()
+		args := []string{
+			"--force", "--sign", "-", "--identifier", "tart-guest-agent",
+			"--options", "runtime", "--timestamp=none",
+		}
+		if entitlements {
+			args = append(args, "--entitlements", filepath.Join(root, "packaging", "macos-entitlements.plist"))
+		}
+		args = append(args, binary)
+		if output, err := exec.CommandContext(t.Context(), "codesign", args...).CombinedOutput(); err != nil {
+			t.Fatalf("sign agent: %v\n%s", err, output)
+		}
+	}
+	verify := func() ([]byte, error) {
+		//nolint:gosec // The script and binary paths are owned by the repository and this test.
+		return exec.CommandContext(t.Context(), "sh",
+			filepath.Join(root, "packaging", "verify-macos-signing.sh"), binary).CombinedOutput()
+	}
+
+	sign(false)
+	output, err := verify()
+	if err == nil || !strings.Contains(string(output), "did not load the injection probe") {
+		t.Fatalf("expected the unentitled hardened agent to reject injection: %v\n%s", err, output)
+	}
+	sign(true)
+	if output, err := verify(); err != nil {
+		t.Fatalf("entitled hardened agent must load the probe: %v\n%s", err, output)
+	}
+}

--- a/packaging/verify-macos-signing.sh
+++ b/packaging/verify-macos-signing.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+set -eu
+
+# Run on the final signed executable, before GoReleaser archives it. Do not
+# modify its signature: image builders depend on its signed TCC identity.
+binary=$1
+work_dir=$(mktemp -d)
+trap 'rm -rf "$work_dir"' EXIT
+
+codesign --verify --all-architectures --strict "$binary"
+for arch in $(lipo -archs "$binary"); do
+  codesign --display --verbose=4 --arch "$arch" "$binary" 2>&1 \
+    | grep -Eq 'flags=.*runtime' || {
+      echo "Hardened Runtime is missing for $arch" >&2
+      exit 1
+    }
+done
+
+# A harmless ad-hoc-signed library exercises the same loading requirements as
+# guest-installed compatibility libraries, without needing Metal hardware.
+cat > "$work_dir/probe.c" <<'EOF'
+#include <stdio.h>
+__attribute__((constructor)) static void loaded(void) {
+  fputs("tart-guest-agent signing probe loaded\n", stderr);
+}
+EOF
+xcrun clang -dynamiclib "$work_dir/probe.c" -o "$work_dir/probe.dylib"
+codesign --force --sign - "$work_dir/probe.dylib"
+DYLD_INSERT_LIBRARIES="$work_dir/probe.dylib" "$binary" --version \
+  > "$work_dir/version" 2> "$work_dir/probe.log"
+if ! grep -Fxq 'tart-guest-agent signing probe loaded' "$work_dir/probe.log"; then
+  echo 'The signed guest agent did not load the injection probe' >&2
+  exit 1
+fi
+
+for arch in $(lipo -archs "$binary"); do
+  codesign --display --arch "$arch" --entitlements - --xml "$binary" \
+    > "$work_dir/entitlements.plist"
+  for key in allow-dyld-environment-variables disable-library-validation; do
+    value=$(/usr/libexec/PlistBuddy -c "Print :com.apple.security.cs.$key" \
+      "$work_dir/entitlements.plist")
+    test "$value" = true || {
+      echo "Missing $key entitlement for $arch" >&2
+      exit 1
+    }
+  done
+done
+echo 'Signed guest-agent library loading verified'


### PR DESCRIPTION
Allow signed macOS builds to load explicitly configured compatibility libraries without re-signing the installed agent. Retain Hardened Runtime and the signing identifier, and apply matching entitlements to snapshots.

The DYLD and library-validation exceptions apply to both agent and daemon modes. No library is configured by default.

Adds a real-agent regression test and a pre-archive signature/loading check. Validated with `go test ./...`, lint, and a universal snapshot release. Production signing still needs verification.
